### PR TITLE
Conform to 5.2's Authenticatable contract

### DIFF
--- a/src/Auth0/Login/Auth0JWTUser.php
+++ b/src/Auth0/Login/Auth0JWTUser.php
@@ -12,6 +12,16 @@ class Auth0JWTUser implements \Illuminate\Contracts\Auth\Authenticatable {
     function __construct ($userInfo) {
         $this->userInfo = get_object_vars($userInfo);
     }
+    
+    /**
+     * Get the unique identifier for the user.
+     *
+     * @return mixed
+     */
+    public function getAuthIdentifierName() {
+        return $this->userInfo['sub'];
+    }
+    
     /**
      * Get the unique identifier for the user.
      *


### PR DESCRIPTION
Laravel 5.2 introduced the `getAuthIdentifierName` abstract function in its Authenticatable contract, throwing an error if `AuthJWTUser` is used to authenticate.

All it needs is the function of its own, which can be identical to `getAuthIdentifier` I believe.